### PR TITLE
Fix issue with storing state updates when handling images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   const [batchFiles, setBatchFiles] = useState<File[] | null>(null)
   const [isProcessing, setIsProcessing] = useState<boolean>(false)
 
-  const processImage = async (file?: File) => {
+  const processImage = async (file?: File, newFormat?: string, newQuality?: number, newWidth?: number, newHeight?: number) => {
     if (!originalImage && !file) return
     
     setIsProcessing(true)
@@ -35,10 +35,10 @@ export default function Home() {
         formData.append('image', blob)
       }
       
-      formData.append('format', format)
-      formData.append('quality', quality.toString())
-      if (width) formData.append('width', width.toString())
-      if (height) formData.append('height', height.toString())
+      formData.append('format', newFormat || format)
+      formData.append('quality', (newQuality || quality).toString())
+      if (newWidth || width) formData.append('width', (newWidth || width).toString())
+      if (newHeight || height) formData.append('height', (newHeight || height).toString())
 
       const response = await fetch('/api/optimize', {
         method: 'POST',
@@ -274,19 +274,19 @@ export default function Home() {
               maintainAspect={maintainAspect}
               onFormatChange={(newFormat) => {
                 setFormat(newFormat)
-                setTimeout(() => processImage(), 100)
+                setTimeout(() => processImage(undefined, newFormat), 100)
               }}
               onQualityChange={(newQuality) => {
                 setQuality(newQuality)
-                setTimeout(() => processImage(), 100)
+                setTimeout(() => processImage(undefined, undefined, newQuality), 100)
               }}
               onWidthChange={(newWidth) => {
                 setWidth(newWidth)
-                setTimeout(() => processImage(), 100)
+                setTimeout(() => processImage(undefined, undefined, undefined, newWidth), 100)
               }}
               onHeightChange={(newHeight) => {
                 setHeight(newHeight)
-                setTimeout(() => processImage(), 100)
+                setTimeout(() => processImage(undefined, undefined, undefined, undefined, newHeight), 100)
               }}
               onMaintainAspectChange={setMaintainAspect}
               onPercentageResize={(percentage) => {
@@ -295,7 +295,7 @@ export default function Home() {
                   const newHeight = Math.round(originalDimensions.height * (percentage / 100))
                   setWidth(newWidth)
                   setHeight(newHeight)
-                  setTimeout(() => processImage(), 100)
+                  setTimeout(() => processImage(undefined, undefined, undefined, newWidth, newHeight), 100)
                 }
               }}
             />


### PR DESCRIPTION
When you store values in state in React, they are not immediately accessible until the next event cycle. 

For immediate use of new values, you'll have to pass them directly to the function that needs them, or you'll have to refresh the component.

This fix passes the new values to the process image method directly